### PR TITLE
fix: correct time clock API URLs

### DIFF
--- a/client/src/components/TimeClock.jsx
+++ b/client/src/components/TimeClock.jsx
@@ -91,11 +91,11 @@ const TimeClock = () => {
         setLoading(true);
         try {
             const token = await auth.currentUser.getIdToken();
-            const response = await fetch('${API_URL}/api/time-clock/status', {
-                headers: { 
-        'Authorization': `Bearer ${token}`,
-        'Content-Type': 'application/json'
-    }
+            const response = await fetch(`${API_URL}/api/time-clock/status`, {
+                headers: {
+                    'Authorization': `Bearer ${token}`,
+                    'Content-Type': 'application/json'
+                }
             });
             
             if (!response.ok) {
@@ -149,7 +149,7 @@ const TimeClock = () => {
         
         try {
             const token = await auth.currentUser.getIdToken();
-            const response = await fetch('${API_URL}/api/time-clock/clock-in', {
+            const response = await fetch(`${API_URL}/api/time-clock/clock-in`, {
                 method: 'POST',
                 headers: { 
                     'Content-Type': 'application/json',
@@ -186,7 +186,7 @@ const TimeClock = () => {
         
         try {
             const token = await auth.currentUser.getIdToken();
-            const response = await fetch('${API_URL}/api/time-clock/clock-out',  {
+            const response = await fetch(`${API_URL}/api/time-clock/clock-out`, {
                 method: 'POST',
                 headers: { 
                     'Content-Type': 'application/json',
@@ -222,7 +222,7 @@ const TimeClock = () => {
         
         try {
             const token = await auth.currentUser.getIdToken();
-            const response = await fetch('${API_URL}/api/time-clock/break-start', {
+            const response = await fetch(`${API_URL}/api/time-clock/break-start`, {
                 method: 'POST',
                 headers: { 
                     'Content-Type': 'application/json',
@@ -255,7 +255,7 @@ const TimeClock = () => {
         
         try {
             const token = await auth.currentUser.getIdToken();
-            const response = await fetch('${API_URL}/api/time-clock/break-end', {
+            const response = await fetch(`${API_URL}/api/time-clock/break-end`, {
                 method: 'POST',
                 headers: { 
                     'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- fix TimeClock API calls to interpolate environment base URL

## Testing
- `npm test` (client) *(fails: Missing script "test")*
- `npm run lint` (client) *(fails: 13 errors, 5 warnings)*
- `npx eslint src/components/TimeClock.jsx`
- `npm test` (server)
- `npm run lint` (server) *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68a211d52658832ba72116be11206a7f