### PR TITLE
feat: add default API URL

### DIFF
--- a/client/src/components/AddExpenseForm.jsx
+++ b/client/src/components/AddExpenseForm.jsx
@@ -4,7 +4,8 @@ import React, { useState, useEffect } from 'react';
 import { auth } from '../firebase';
 
 // Environment-based API configuration
-const API_BASE_URL = import.meta.env.VITE_API_URL ;
+// Fallback to local server if the environment variable is undefined
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
 
 const AddExpenseForm = ({ onNewExpense, transactionToEdit, onUpdate, onCancelEdit }) => {
     const [description, setDescription] = useState('');


### PR DESCRIPTION
## Summary
- default AddExpenseForm API URL to localhost:5000 when VITE_API_URL is undefined

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 13 errors, 4 warnings)*
- `npm test` (server) *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a2138530e4832ba7604abdd39386c5