### PR TITLE
fix transaction list hover shade

### DIFF
--- a/client/src/components/TransactionList.jsx
+++ b/client/src/components/TransactionList.jsx
@@ -108,7 +108,7 @@ const TransactionList = ({ title, transactions, userProfile, onEdit, onActionCom
             
             <div className="space-y-3 max-h-96 overflow-y-auto">
                 {transactions.map(t => (
-                    <div key={t.id} className="bg-slate-700 border border-slate-600 p-4 rounded-lg hover:bg-slate-650 transition-all duration-200 shadow-lg">
+                    <div key={t.id} className="bg-slate-700 border border-slate-600 p-4 rounded-lg hover:bg-slate-600 transition-all duration-200 shadow-lg">
                         <div className="flex justify-between items-start">
                             {/* Left side: Description and Metadata */}
                             <div className="flex-1 min-w-0">


### PR DESCRIPTION
## Summary
- replace invalid `hover:bg-slate-650` with valid `hover:bg-slate-600` in TransactionList component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 13 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a21386e04c832bbe2ac7155e1459f1