### PR TITLE
Add test for AnalyticsService hourly averages

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/server/tests/analyticsService.test.js
+++ b/server/tests/analyticsService.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const AnalyticsService = require('../services/analyticsService');
+
+test('calculateHourlyAverages returns zeros for all 24 hours when given empty data', () => {
+  const result = AnalyticsService.calculateHourlyAverages([]);
+  assert.strictEqual(Object.keys(result).length, 24);
+  for (let hour = 0; hour < 24; hour++) {
+    assert.deepStrictEqual(result[hour], { avgTransactions: 0, avgAmount: 0, dataPoints: 0 });
+  }
+});


### PR DESCRIPTION
## Summary
- add Node test verifying `calculateHourlyAverages` returns zeroed stats for all 24 hours when given no data
- enable running tests via `npm test` by using Node's built-in test runner

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a213815ec4832b9db79c731fddd1a4