### PR TITLE
Handle missing Firebase private key

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -39,10 +39,17 @@ const notificationRoutes = require('./routes/notifications');
 
 const db = require('./database.js');
 
+const firebasePrivateKey = process.env.FIREBASE_PRIVATE_KEY;
+
+if (!firebasePrivateKey) {
+  console.error('FIREBASE_PRIVATE_KEY environment variable is not set.');
+  process.exit(1);
+}
+
 const firebaseCert = {
   projectId: process.env.FIREBASE_PROJECT_ID,
   clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-  privateKey: process.env.FIREBASE_PRIVATE_KEY.replace(/\\n/g, '\n')
+  privateKey: firebasePrivateKey.replace(/\\n/g, '\n')
 };
 
 admin.initializeApp({


### PR DESCRIPTION
## Summary
- validate `FIREBASE_PRIVATE_KEY` before using it and exit with a clear error when missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a25ec6b5e0832bbcd4827fde19b8c6