### PR TITLE
Use PUT for notification read operations

### DIFF
--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -535,18 +535,18 @@ class ApiService {
 
     async markNotificationRead(id) {
         const result = await this.authenticatedRequest(`/api/notifications/${id}/read`, {
-            method: 'POST',
+            method: 'PUT',
         });
-        
+
         this.clearCachePattern('/api/notifications');
         return result;
     }
 
     async markAllNotificationsRead() {
         const result = await this.authenticatedRequest('/api/notifications/mark-all-read', {
-            method: 'POST',
+            method: 'PUT',
         });
-        
+
         this.clearCachePattern('/api/notifications');
         return result;
     }


### PR DESCRIPTION
## Summary
- Use HTTP PUT for marking notifications read
- Ensure notification cache invalidation remains

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: TimeEntriesAdminPage: 'API_URL' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a25ecc6e1c832b811024cc7e3d98ac