### PR TITLE
Add auth and transactions routers

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -36,6 +36,8 @@ const {
 const { logActivity, createNotification } = activityService;
 const analyticsRoutes = require('./routes/analytics');
 const notificationRoutes = require('./routes/notifications');
+const authRoutes = require('./routes/auth');
+const transactionRoutes = require('./routes/transactions');
 
 const db = require('./database.js');
 
@@ -181,7 +183,7 @@ const limiter = rateLimit({
 });
 
 app.use('/api/', limiter);
-app.use('/api/auth', authRateLimit);
+app.use('/api/auth', authRateLimit, authRoutes);
 app.use('/api/login', loginRateLimit);
 
 app.use(express.json({ limit: '10mb' }));
@@ -192,7 +194,7 @@ app.use('/uploads', express.static('uploads'));
 
 // Authentication middleware
 // Apply auth middleware to protected routes
-app.use('/api/transactions', authMiddleware);
+app.use('/api/transactions', transactionRoutes);
 app.use('/api/employees', authMiddleware);
 app.use('/api/users', authMiddleware, adminOnly);
 app.use('/api/rota', authMiddleware);

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const admin = require('firebase-admin');
+const router = express.Router();
+const db = require('../database');
+const { authMiddleware } = require('../middleware/auth');
+
+// Register a new user using Firebase Authentication
+router.post('/register', async (req, res) => {
+    const { email, password, role = 'staff' } = req.body;
+    if (!email || !password) {
+        return res.status(400).json({ error: 'Email and password are required' });
+    }
+    try {
+        const userRecord = await admin.auth().createUser({ email, password });
+        await db.query(
+            'INSERT INTO users (uid, email, role, status) VALUES ($1, $2, $3, $4) ON CONFLICT (uid) DO NOTHING',
+            [userRecord.uid, email, role, 'active']
+        );
+        res.status(201).json({ message: 'User registered successfully', uid: userRecord.uid });
+    } catch (err) {
+        console.error('Registration error:', err);
+        res.status(500).json({ error: 'Failed to register user' });
+    }
+});
+
+// Login expects a Firebase ID token from the client and verifies it
+router.post('/login', async (req, res) => {
+    const { token } = req.body;
+    if (!token) {
+        return res.status(400).json({ error: 'Token is required' });
+    }
+    try {
+        const decoded = await admin.auth().verifyIdToken(token);
+        res.json({ uid: decoded.uid, email: decoded.email });
+    } catch (err) {
+        console.error('Login error:', err);
+        res.status(401).json({ error: 'Invalid token' });
+    }
+});
+
+// Return information about the currently authenticated user
+router.get('/me', authMiddleware, async (req, res) => {
+    res.json({ user: req.user });
+});
+
+module.exports = router;

--- a/server/routes/transactions.js
+++ b/server/routes/transactions.js
@@ -1,0 +1,96 @@
+const express = require('express');
+const router = express.Router();
+const db = require('../database');
+const { authMiddleware } = require('../middleware/auth');
+
+// Protect all routes below
+router.use(authMiddleware);
+
+// List transactions for the authenticated user
+router.get('/', async (req, res) => {
+    try {
+        const { rows } = await db.query(
+            'SELECT * FROM transactions WHERE user_uid = $1 ORDER BY transaction_date DESC',
+            [req.user.uid]
+        );
+        res.json({ data: rows });
+    } catch (err) {
+        console.error('Error fetching transactions:', err);
+        res.status(500).json({ error: 'Failed to fetch transactions' });
+    }
+});
+
+// Create a new transaction
+router.post('/', async (req, res) => {
+    const { description, amount, type, category, notes } = req.body;
+    if (!description || !amount || !type) {
+        return res.status(400).json({ error: 'description, amount and type are required' });
+    }
+    try {
+        const { rows } = await db.query(
+            `INSERT INTO transactions (user_uid, description, amount, type, category, notes)
+             VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`,
+            [req.user.uid, description, amount, type, category || null, notes || null]
+        );
+        res.status(201).json({ message: 'Transaction created', data: rows[0] });
+    } catch (err) {
+        console.error('Error creating transaction:', err);
+        res.status(500).json({ error: 'Failed to create transaction' });
+    }
+});
+
+// Retrieve a single transaction
+router.get('/:id', async (req, res) => {
+    try {
+        const { rows } = await db.query(
+            'SELECT * FROM transactions WHERE id = $1 AND user_uid = $2',
+            [req.params.id, req.user.uid]
+        );
+        if (rows.length === 0) {
+            return res.status(404).json({ error: 'Transaction not found' });
+        }
+        res.json({ data: rows[0] });
+    } catch (err) {
+        console.error('Error fetching transaction:', err);
+        res.status(500).json({ error: 'Failed to fetch transaction' });
+    }
+});
+
+// Update a transaction
+router.put('/:id', async (req, res) => {
+    const { description, amount, type, category, notes } = req.body;
+    try {
+        const { rows } = await db.query(
+            `UPDATE transactions
+             SET description = $1, amount = $2, type = $3, category = $4, notes = $5, updated_at = NOW()
+             WHERE id = $6 AND user_uid = $7 RETURNING *`,
+            [description, amount, type, category || null, notes || null, req.params.id, req.user.uid]
+        );
+        if (rows.length === 0) {
+            return res.status(404).json({ error: 'Transaction not found' });
+        }
+        res.json({ message: 'Transaction updated', data: rows[0] });
+    } catch (err) {
+        console.error('Error updating transaction:', err);
+        res.status(500).json({ error: 'Failed to update transaction' });
+    }
+});
+
+// Delete a transaction
+router.delete('/:id', async (req, res) => {
+    try {
+        const { rows } = await db.query(
+            'DELETE FROM transactions WHERE id = $1 AND user_uid = $2 RETURNING *',
+            [req.params.id, req.user.uid]
+        );
+        if (rows.length === 0) {
+            return res.status(404).json({ error: 'Transaction not found' });
+        }
+        res.json({ message: 'Transaction deleted', data: rows[0] });
+    } catch (err) {
+        console.error('Error deleting transaction:', err);
+        res.status(500).json({ error: 'Failed to delete transaction' });
+    }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- implement authentication router for registration, login, and profile lookup
- add CRUD router for user transactions
- hook auth and transaction routers into main server

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a25ecef72c832bb16c6076363cd41c