### PR TITLE
feat: fallback to default API URL with warning

### DIFF
--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -2,7 +2,10 @@
 
 class ApiService {
     constructor() {
-        this.baseURL = import.meta.env.VITE_API_URL;
+        this.baseURL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
+        if (!import.meta.env.VITE_API_URL) {
+            console.warn('VITE_API_URL is not set, using default http://localhost:5000');
+        }
         this.timeout = 30000;
         this.cache = new Map();
         this.cacheTimeout = 5 * 60 * 1000; // 5 minutes


### PR DESCRIPTION
## Summary
- warn and fallback to http://localhost:5000 when VITE_API_URL is not set

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 13 errors, 5 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a25ed11abc832b9a90bb846ff309d6