### PR TITLE
fix: remove duplicate time_entries total_hours alteration

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -207,7 +207,6 @@ await client.query(`
     await client.query(`ALTER TABLE rota_shifts ADD COLUMN IF NOT EXISTS published_by TEXT;`);
     await client.query(`ALTER TABLE rota_shifts ADD COLUMN IF NOT EXISTS status TEXT DEFAULT 'scheduled';`);
     await client.query(`ALTER TABLE time_entries ADD COLUMN IF NOT EXISTS user_email TEXT;`);
-    await client.query(`ALTER TABLE time_entries ADD COLUMN IF NOT EXISTS total_hours NUMERIC(5,2);`);
     await client.query(`ALTER TABLE time_entries ADD COLUMN IF NOT EXISTS notes TEXT;`);
     await client.query(`ALTER TABLE time_entries ADD COLUMN IF NOT EXISTS location TEXT;`);
     await client.query(`ALTER TABLE activity_logs ADD COLUMN IF NOT EXISTS ip_address INET,ADD COLUMN IF NOT EXISTS user_agent TEXT;`);


### PR DESCRIPTION
## Summary
- remove duplicate total_hours ALTER TABLE statement in database setup
- verify surrounding schema alterations contain no other duplicates

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a25ed2ad88832bb53a496e4b3d3de3